### PR TITLE
Make API changes for compatibility with new osim-rl-grader

### DIFF
--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -41,9 +41,8 @@ observation = client.env_create(args.token)
 # Run a single step
 for i in range(501):
     v = np.array(observation).reshape((-1,1,env.observation_space.shape[0]))
-    [observation, reward, done, info] = client.env_step(args.token, actor.predict(v)[0].tolist(), True)
+    [observation, reward, done, info] = client.env_step(actor.predict(v)[0].tolist(), True)
     if done:
         break
 
 client.submit(args.token)
-

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 # This provides the variable `__version__`.
 # execfile('opensim/version.py')
-__version__ = 1.1
+__version__ = 1.2
 
 setup(name='osim-rl',
       version=__version__,


### PR DESCRIPTION
The token used by the user should be unique per submission and not equal to the user API key. This enables us to store all the actions, observations sequences from all the submission simulations. 
This makes the API interface more closer to that of gym envs.