### PR TITLE
Make osim/env/run.py python 3.6 compatible

### DIFF
--- a/osim/env/run.py
+++ b/osim/env/run.py
@@ -109,7 +109,7 @@ class RunEnv(OsimEnv):
             if obstacle[0] + obstacle[2] < x:
                 continue
             else:
-                return map(lambda xy: xy[0]-xy[1], [o for o in zip(obstacle, [x,0,0])])
+                return list(map(lambda xy: xy[0]-xy[1], [o for o in zip(obstacle, [x,0,0])]))
         return [100,0,0]
         
 


### PR DESCRIPTION
Updated file to work with python3.6, else it will fail with the following error:

```
Traceback (most recent call last):
  File "example.py", line 86, in <module>
    agent.fit(env, nb_steps=nallsteps, visualize=False, verbose=1, nb_max_episode_steps=env.timestep_limit, log_interval=10000)
  File "/opt/conda/envs/opensim-rl/lib/python3.6/site-packages/rl/core.py", line 123, in fit
    observation = deepcopy(env.reset())
  File "/osim-rl/osim/env/run.py", line 53, in reset
    super(RunEnv, self).reset()
  File "/opt/conda/envs/opensim-rl/lib/python3.6/site-packages/gym/core.py", line 104, in reset
    return self._reset()
  File "/osim-rl/osim/env/osim.py", line 145, in _reset
    return self.get_observation()
  File "/osim-rl/osim/env/run.py", line 136, in get_observation
    self.current_state = pelvis_pos + pelvis_vel + joint_angles + joint_vel + mass_pos + mass_vel + [item for sublist in body_transforms for item in sublist] + muscles + obstacle
TypeError: can only concatenate list (not "map") to list
```