### PR TITLE
Fix type error: --steps was string instead of int

### DIFF
--- a/scripts/example.py
+++ b/scripts/example.py
@@ -24,7 +24,7 @@ import math
 parser = argparse.ArgumentParser(description='Train or test neural net motor controller')
 parser.add_argument('--train', dest='train', action='store_true', default=True)
 parser.add_argument('--test', dest='train', action='store_false', default=True)
-parser.add_argument('--steps', dest='steps', action='store', default=10000)
+parser.add_argument('--steps', dest='steps', action='store', default=10000, type=int)
 parser.add_argument('--visualize', dest='visualize', action='store_true', default=False)
 parser.add_argument('--model', dest='model', action='store', default="example.h5f")
 args = parser.parse_args()


### PR DESCRIPTION
--steps flag was not working properly.

For example --steps 10 was ignored, because string '10'
was passed to keras-rl fit function as nb_steps (instead of int(10)),
which resulted in infinite loop.