### PR TITLE
Fix 2 warnings by not using deprecated Keras API

### DIFF
--- a/scripts/example.py
+++ b/scripts/example.py
@@ -4,7 +4,7 @@ import numpy as np
 import sys
 
 from keras.models import Sequential, Model
-from keras.layers import Dense, Activation, Flatten, Input, merge
+from keras.layers import Dense, Activation, Flatten, Input, concatenate
 from keras.optimizers import Adam
 
 import numpy as np
@@ -55,7 +55,7 @@ print(actor.summary())
 action_input = Input(shape=(nb_actions,), name='action_input')
 observation_input = Input(shape=(1,) + env.observation_space.shape, name='observation_input')
 flattened_observation = Flatten()(observation_input)
-x = merge([action_input, flattened_observation], mode='concat')
+x = concatenate([action_input, flattened_observation])
 x = Dense(64)(x)
 x = Activation('relu')(x)
 x = Dense(64)(x)
@@ -64,7 +64,7 @@ x = Dense(64)(x)
 x = Activation('relu')(x)
 x = Dense(1)(x)
 x = Activation('linear')(x)
-critic = Model(input=[action_input, observation_input], output=x)
+critic = Model(inputs=[action_input, observation_input], outputs=x)
 print(critic.summary())
 
 # Set up the agent for training


### PR DESCRIPTION
Fixes 2 warnings:

example.py:58: UserWarning: The `merge` function is deprecated and will be removed after 08/2017. Use instead layers from `keras.layers.merge`, e.g. `add`, `concatenate`, etc.
  x = merge([action_input, flattened_observation], mode='concat')
/home/adam/anaconda2/envs/opensim-rl/lib/python2.7/site-packages/keras/legacy/layers.py:456: UserWarning: The `Merge` layer is deprecated and will be removed after 08/2017. Use instead layers from `keras.layers.merge`, e.g. `add`, `concatenate`, etc.
  name=name)

example.py:67: UserWarning: Update your `Model` call to the Keras 2 API: `Model(outputs=Tensor("de..., inputs=[<tf.Tenso...)`
  critic = Model(input=[action_input, observation_input], output=x)