### PR TITLE
Fix potential bug with muscle observations

### DIFF
--- a/osim/env/osim.py
+++ b/osim/env/osim.py
@@ -464,7 +464,7 @@ class ProstheticsEnv(OsimEnv):
             res += state_desc["joint_vel"][joint]
             res += state_desc["joint_acc"][joint]
 
-        for muscle in state_desc["muscles"].keys():
+        for muscle in sorted(state_desc["muscles"].keys()):
             res += [state_desc["muscles"][muscle]["activation"]]
             res += [state_desc["muscles"][muscle]["fiber_length"]]
             res += [state_desc["muscles"][muscle]["fiber_velocity"]]
@@ -511,7 +511,7 @@ class Arm2DEnv(OsimEnv):
             res += state_desc["joint_vel"][joint]
             res += state_desc["joint_acc"][joint]
 
-        for muscle in state_desc["muscles"].keys():
+        for muscle in sorted(state_desc["muscles"].keys()):
             res += [state_desc["muscles"][muscle]["activation"]]
             # res += [state_desc["muscles"][muscle]["fiber_length"]]
             # res += [state_desc["muscles"][muscle]["fiber_velocity"]]


### PR DESCRIPTION
Dict's key() method can return values in arbitatry order,
which could be dramatic for RL agent's observation. Better to use
sorted() here.