### PR TITLE
Fixed typo in docs for osim-rl repo link

### DIFF
--- a/docs/_docs/training.md
+++ b/docs/_docs/training.md
@@ -24,7 +24,7 @@ Below we present how to train a basic controller using [keras-rl](https://github
 
     conda install keras -c conda-forge
     pip install tensorflow git+https://github.com/matthiasplappert/keras-rl.git
-    git clone http://github.com/stanfordnmbl/osim-rl.git
+    git clone https://github.com/stanfordnmbl/osim-rl.git
 
 `keras-rl` is an excellent package compatible with [OpenAI](http://openai.com/), which allows you to quickly build your first models!
 


### PR DESCRIPTION
The link for cloning the git repo is https not http